### PR TITLE
Implement proper CLI subcommands with Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ go install github.com/0xReLogic/SENTINEL@latest
 ./sentinel validate
 
 # Display help
-./sentinel help
+./sentinel --help
+
+# Use custom configuration file
+./sentinel run --config /path/to/config.yaml
 ```
 
 ## Configuration Structure
@@ -89,6 +92,7 @@ services:
 ```
 SENTINEL/
 ├── checker/       # Package for service checking
+├── cmd/           # CLI commands
 ├── config/        # Package for configuration management
 ├── main.go        # Main program file
 ├── Makefile       # Makefile for easier build and test

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -155,6 +155,9 @@ services:
 	weirdPath := "./././sentinel.yaml"
 	configPath = weirdPath
 	_, err = loadConfig()
+	if err == nil {
+		t.Error("Expected error for non-existent weird path config file")
+	}
 	commentConfig := `
 # This is just a comment
 services: []

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,0 +1,78 @@
+package cmd
+
+import "time"
+
+// application constants
+const (
+	// application name and metadata
+	appName       = "sentinel"
+	appRepository = "https://github.com/0xReLogic/SENTINEL"
+
+	// command names
+	cmdNameRun      = "run"
+	cmdNameOnce     = "once"
+	cmdNameValidate = "validate"
+
+	// flag names
+	flagConfig      = "config"
+	flagConfigShort = "c"
+
+	// default configuration
+	defaultConfigFile = "sentinel.yaml"
+	checkInterval     = 1 * time.Minute
+
+	// timestamp format (Go reference time)
+	timestampFormat = "2006-01-02 15:04:05"
+
+	// allowed URL schemes
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+
+	// exit codes
+	exitSuccess     = 0
+	exitError       = 1
+	exitConfigError = 2
+
+	// display formatting
+	separator  = "-----------------------------------"
+	indent     = "  "
+	listPrefix = "  - "
+
+	// banner messages
+	bannerTitle           = "SENTINEL Monitoring System"
+	bannerExitInstruction = "Press Ctrl+C to exit"
+
+	// validation messages
+	msgValidationFailed   = "Configuration validation failed:\n"
+	msgValidationSuccess  = "Configuration is valid"
+	msgNoServicesDefined  = "No services defined"
+	msgServicesConfigured = "Services configured:"
+
+	// check messages
+	msgRunningChecks = "Running service checks..."
+
+	// error messages
+	errLoadingConfig     = "Error loading configuration: %v\n"
+	errInvalidConfigPath = "invalid config path: %w"
+	errConfigNotFound    = "config file not found: %s\nCreate a %s file or use --%s flag"
+	errServiceNameReq    = "service #%d: name is required"
+	errServiceURLReq     = "service #%d (%s): URL is required"
+	errServiceURLInvalid = "service #%d (%s): invalid URL format '%s'"
+
+	// command descriptions
+	descShort      = "A simple and effective monitoring system"
+	descLong       = "SENTINEL monitors web services via HTTP and reports their status.\nPerfect for personal use or small teams needing lightweight monitoring.\n\nRepository: %s"
+	descRunShort   = "Run continuous monitoring"
+	descRunLong    = "Start SENTINEL in continuous monitoring mode. Checks run every minute."
+	descOnceShort  = "Run checks once and exit"
+	descOnceLong   = "Run service checks once and exit. Useful for cron jobs or CI/CD pipelines.\n\nExit codes:\n  %d - All services are UP\n  %d - One or more services are DOWN\n  %d - Configuration error"
+	descValidShort = "Validate configuration file"
+	descValidLong  = "Validate the configuration file for syntax and content errors."
+	descConfigFlag = "path to configuration file"
+
+	// message formats
+	fmtLoadedServices           = "Loaded %d services to monitor\n"
+	fmtLoadedServicesValidation = "Loaded %d services\n\n"
+	fmtServiceListItem          = "  %d. %s - %s\n"
+	fmtTimestamp                = "\n[%s] %s\n"
+)

--- a/cmd/once.go
+++ b/cmd/once.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/0xReLogic/SENTINEL/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +21,7 @@ var onceCmd = &cobra.Command{
 		}
 
 		// run checks once
-		fmt.Printf(fmtTimestamp, time.Now().Format(timestampFormat), msgRunningChecks)
-
-		allUp := runChecksWithStatus(cfg)
-
-		fmt.Println(separator)
+		allUp := runChecksAndGetStatus(cfg)
 
 		// exit with appropriate code
 		if !allUp {
@@ -39,9 +33,4 @@ var onceCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(onceCmd)
-}
-
-// runChecksWithStatus performs checks and returns overall status
-func runChecksWithStatus(cfg *config.Config) bool {
-	return runChecksAndGetStatus(cfg)
 }

--- a/cmd/once.go
+++ b/cmd/once.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/0xReLogic/SENTINEL/checker"
 	"github.com/0xReLogic/SENTINEL/config"
 	"github.com/spf13/cobra"
 )
@@ -44,16 +43,5 @@ func init() {
 
 // runChecksWithStatus performs checks and returns overall status
 func runChecksWithStatus(cfg *config.Config) bool {
-	allUp := true
-
-	for _, service := range cfg.Services {
-		status := checker.CheckService(service.Name, service.URL)
-		fmt.Println(status)
-
-		if !status.IsUp {
-			allUp = false
-		}
-	}
-
-	return allUp
+	return runChecksAndGetStatus(cfg)
 }

--- a/cmd/once.go
+++ b/cmd/once.go
@@ -14,7 +14,7 @@ var onceCmd = &cobra.Command{
 	Long:  fmt.Sprintf(descOnceLong, exitSuccess, exitError, exitConfigError),
 	Run: func(cmd *cobra.Command, args []string) {
 		// load configuration
-		cfg, err := loadConfig()
+		cfg, err := loadConfig(configPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, errLoadingConfig, err)
 			os.Exit(exitConfigError)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/0xReLogic/SENTINEL/checker"
 	"github.com/0xReLogic/SENTINEL/config"
 	"github.com/spf13/cobra"
 )
@@ -84,4 +86,22 @@ func isValidURL(urlStr string) bool {
 	u, err := url.Parse(urlStr)
 	return err == nil && u.Scheme != "" && u.Host != "" &&
 		(u.Scheme == schemeHTTP || u.Scheme == schemeHTTPS)
+}
+
+// runChecksAndGetStatus performs checks, prints status, and returns overall status
+func runChecksAndGetStatus(cfg *config.Config) bool {
+	fmt.Printf(fmtTimestamp, time.Now().Format(timestampFormat), msgRunningChecks)
+	allUp := true
+
+	for _, service := range cfg.Services {
+		status := checker.CheckService(service.Name, service.URL)
+		fmt.Println(status)
+
+		if !status.IsUp {
+			allUp = false
+		}
+	}
+
+	fmt.Println(separator)
+	return allUp
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,87 @@
+// Package cmd implements the command-line interface for SENTINEL
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/0xReLogic/SENTINEL/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// configPath holds the path to the configuration file
+	configPath string
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   appName,
+	Short: descShort,
+	Long:  fmt.Sprintf(descLong, appRepository),
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(exitError)
+	}
+}
+
+func init() {
+	// add persistent flags that are available to all subcommands
+	rootCmd.PersistentFlags().StringVarP(&configPath, flagConfig, flagConfigShort,
+		defaultConfigFile, descConfigFlag)
+}
+
+// loadConfig loads configuration from the specified path with helpful error messages
+func loadConfig() (*config.Config, error) {
+	absPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf(errInvalidConfigPath, err)
+	}
+
+	cfg, err := config.LoadConfig(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf(errConfigNotFound, configPath, defaultConfigFile, flagConfig)
+		}
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// validateServices validates all services in the configuration
+func validateServices(services []config.Service) []error {
+	var errors []error
+
+	for i, service := range services {
+		if service.Name == "" {
+			errors = append(errors,
+				fmt.Errorf(errServiceNameReq, i+1))
+		}
+		if service.URL == "" {
+			errors = append(errors,
+				fmt.Errorf(errServiceURLReq, i+1, service.Name))
+		}
+		// validate URL format if provided
+		if service.URL != "" && !isValidURL(service.URL) {
+			errors = append(errors,
+				fmt.Errorf(errServiceURLInvalid, i+1, service.Name, service.URL))
+		}
+	}
+
+	return errors
+}
+
+// isValidURL checks if a string is a valid HTTP/HTTPS URL
+func isValidURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	return err == nil && u.Scheme != "" && u.Host != "" &&
+		(u.Scheme == schemeHTTP || u.Scheme == schemeHTTPS)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,8 +41,8 @@ func init() {
 }
 
 // loadConfig loads configuration from the specified path with helpful error messages
-func loadConfig() (*config.Config, error) {
-	absPath, err := filepath.Abs(configPath)
+func loadConfig(path string) (*config.Config, error) {
+	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf(errInvalidConfigPath, err)
 	}
@@ -50,7 +50,7 @@ func loadConfig() (*config.Config, error) {
 	cfg, err := config.LoadConfig(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf(errConfigNotFound, configPath, defaultConfigFile, flagConfig)
+			return nil, fmt.Errorf(errConfigNotFound, path, defaultConfigFile, flagConfig)
 		}
 		return nil, err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,7 @@ var runCmd = &cobra.Command{
 	Long:  descRunLong,
 	Run: func(cmd *cobra.Command, args []string) {
 		// load configuration
-		cfg, err := loadConfig()
+		cfg, err := loadConfig(configPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, errLoadingConfig, err)
 			os.Exit(exitConfigError)
@@ -30,11 +30,11 @@ var runCmd = &cobra.Command{
 		defer ticker.Stop()
 
 		// run the first check immediately
-		runChecks(cfg)
+		runChecksAndGetStatus(cfg)
 
 		// then run on ticker schedule
 		for range ticker.C {
-			runChecks(cfg)
+			runChecksAndGetStatus(cfg)
 		}
 	},
 }
@@ -49,9 +49,4 @@ func printBanner(cfg *config.Config) {
 	fmt.Printf(fmtLoadedServices, len(cfg.Services))
 	fmt.Println(bannerExitInstruction)
 	fmt.Println(separator)
-}
-
-// runChecks performs continuous monitoring using the shared function
-func runChecks(cfg *config.Config) {
-	runChecksAndGetStatus(cfg)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,7 +20,7 @@ var runCmd = &cobra.Command{
 		cfg, err := loadConfig()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, errLoadingConfig, err)
-			os.Exit(exitError)
+			os.Exit(exitConfigError)
 		}
 
 		// print startup banner

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/0xReLogic/SENTINEL/checker"
 	"github.com/0xReLogic/SENTINEL/config"
 	"github.com/spf13/cobra"
 )
@@ -52,14 +51,7 @@ func printBanner(cfg *config.Config) {
 	fmt.Println(separator)
 }
 
-// runChecks performs checks on all services in the configuration
+// runChecks performs continuous monitoring
 func runChecks(cfg *config.Config) {
-	fmt.Printf(fmtTimestamp, time.Now().Format(timestampFormat), msgRunningChecks)
-
-	for _, service := range cfg.Services {
-		status := checker.CheckService(service.Name, service.URL)
-		fmt.Println(status)
-	}
-
-	fmt.Println(separator)
+	runChecksAndGetStatus(cfg)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/0xReLogic/SENTINEL/checker"
+	"github.com/0xReLogic/SENTINEL/config"
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   cmdNameRun,
+	Short: descRunShort,
+	Long:  descRunLong,
+	Run: func(cmd *cobra.Command, args []string) {
+		// load configuration
+		cfg, err := loadConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, errLoadingConfig, err)
+			os.Exit(exitError)
+		}
+
+		// print startup banner
+		printBanner(cfg)
+
+		// create a ticker that triggers at the configured interval
+		ticker := time.NewTicker(checkInterval)
+		defer ticker.Stop()
+
+		// run the first check immediately
+		runChecks(cfg)
+
+		// then run on ticker schedule
+		for range ticker.C {
+			runChecks(cfg)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}
+
+// printBanner displays the startup banner
+func printBanner(cfg *config.Config) {
+	fmt.Println(bannerTitle)
+	fmt.Printf(fmtLoadedServices, len(cfg.Services))
+	fmt.Println(bannerExitInstruction)
+	fmt.Println(separator)
+}
+
+// runChecks performs checks on all services in the configuration
+func runChecks(cfg *config.Config) {
+	fmt.Printf(fmtTimestamp, time.Now().Format(timestampFormat), msgRunningChecks)
+
+	for _, service := range cfg.Services {
+		status := checker.CheckService(service.Name, service.URL)
+		fmt.Println(status)
+	}
+
+	fmt.Println(separator)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -51,7 +51,7 @@ func printBanner(cfg *config.Config) {
 	fmt.Println(separator)
 }
 
-// runChecks performs continuous monitoring
+// runChecks performs continuous monitoring using the shared function
 func runChecks(cfg *config.Config) {
 	runChecksAndGetStatus(cfg)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -18,14 +18,14 @@ var validateCmd = &cobra.Command{
 		if err != nil {
 			fmt.Fprint(os.Stderr, msgValidationFailed)
 			fmt.Fprintf(os.Stderr, indent+"%v\n", err)
-			os.Exit(exitError)
+			os.Exit(exitConfigError)
 		}
 
 		// validate that services exist
 		if len(cfg.Services) == 0 {
 			fmt.Fprint(os.Stderr, msgValidationFailed)
 			fmt.Fprintln(os.Stderr, indent+msgNoServicesDefined)
-			os.Exit(exitError)
+			os.Exit(exitConfigError)
 		}
 
 		// validate each service
@@ -35,7 +35,7 @@ var validateCmd = &cobra.Command{
 			for _, err := range errors {
 				fmt.Fprintf(os.Stderr, listPrefix+"%v\n", err)
 			}
-			os.Exit(exitError)
+			os.Exit(exitConfigError)
 		}
 
 		// validation successful

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -14,7 +14,7 @@ var validateCmd = &cobra.Command{
 	Long:  descValidLong,
 	Run: func(cmd *cobra.Command, args []string) {
 		// load configuration
-		cfg, err := loadConfig()
+		cfg, err := loadConfig(configPath)
 		if err != nil {
 			fmt.Fprint(os.Stderr, msgValidationFailed)
 			fmt.Fprintf(os.Stderr, indent+"%v\n", err)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// validateCmd represents the validate command
+var validateCmd = &cobra.Command{
+	Use:   cmdNameValidate,
+	Short: descValidShort,
+	Long:  descValidLong,
+	Run: func(cmd *cobra.Command, args []string) {
+		// load configuration
+		cfg, err := loadConfig()
+		if err != nil {
+			fmt.Fprint(os.Stderr, msgValidationFailed)
+			fmt.Fprintf(os.Stderr, indent+"%v\n", err)
+			os.Exit(exitError)
+		}
+
+		// validate that services exist
+		if len(cfg.Services) == 0 {
+			fmt.Fprint(os.Stderr, msgValidationFailed)
+			fmt.Fprintln(os.Stderr, indent+msgNoServicesDefined)
+			os.Exit(exitError)
+		}
+
+		// validate each service
+		errors := validateServices(cfg.Services)
+		if len(errors) > 0 {
+			fmt.Fprint(os.Stderr, msgValidationFailed)
+			for _, err := range errors {
+				fmt.Fprintf(os.Stderr, listPrefix+"%v\n", err)
+			}
+			os.Exit(exitError)
+		}
+
+		// validation successful
+		fmt.Println(msgValidationSuccess)
+		fmt.Printf(fmtLoadedServicesValidation, len(cfg.Services))
+		fmt.Println(msgServicesConfigured)
+		for i, service := range cfg.Services {
+			fmt.Printf(fmtServiceListItem, i+1, service.Name, service.URL)
+		}
+		os.Exit(exitSuccess)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -3,62 +3,8 @@
 
 package main
 
-import (
-	"fmt"
-	"log"
-	"os"
-	"path/filepath"
-	"time"
-
-	"github.com/0xReLogic/SENTINEL/checker"
-	"github.com/0xReLogic/SENTINEL/config"
-)
+import "github.com/0xReLogic/SENTINEL/cmd"
 
 func main() {
-	// Get the current working directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("Error getting current directory: %v", err)
-	}
-
-	// Construct the path to the config file
-	configPath := filepath.Join(cwd, "sentinel.yaml")
-
-	// Load the configuration
-	cfg, err := config.LoadConfig(configPath)
-	if err != nil {
-		log.Fatalf("Error loading configuration: %v", err)
-	}
-
-	fmt.Println("SENTINEL Monitoring System")
-	fmt.Printf("Loaded %d services to monitor\n", len(cfg.Services))
-	fmt.Println("Press Ctrl+C to exit")
-	fmt.Println("-----------------------------------")
-
-	// Create a ticker that triggers every minute
-	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
-
-	// Run the first check immediately
-	runChecks(cfg)
-
-	// Then run on ticker schedule
-	for range ticker.C {
-		runChecks(cfg)
-	}
-}
-
-// runChecks performs checks on all services in the configuration
-func runChecks(cfg *config.Config) {
-	fmt.Printf("\n[%s] Running service checks...\n", time.Now().Format("2006-01-02 15:04:05"))
-
-	for _, service := range cfg.Services {
-		// Check the service
-		status := checker.CheckService(service.Name, service.URL)
-
-		// Print the result
-		fmt.Println(status)
-	}
-
-	fmt.Println("-----------------------------------")
+	cmd.Execute()
 }


### PR DESCRIPTION
**This pr addresses Issue #1** 

completely rebuilt the CLI using the Cobra framework to give users proper command control. 
Run ./sentinel run for continuous monitoring
Run ./sentinel once for single checks with exit codes
Run ./sentinel validate to check if their config file is valid

All existing functionality still works exactly the same
also, no breaking changes for current users
also followed best practices and made sure to use constants instead of magic strings

added comprehensive tests and used cmd file structure for better maintainability.


